### PR TITLE
Use surface's transparent color in rendering

### DIFF
--- a/lib/graphics/src/Surface.cpp
+++ b/lib/graphics/src/Surface.cpp
@@ -63,7 +63,7 @@ namespace graphics
                 &m_sprite,
                 x,
                 y,
-                m_transparent_color);
+                surface->m_transparent_color);
         }
         else
         {
@@ -91,7 +91,7 @@ namespace graphics
                 0,
                 scale,
                 scale,
-                m_transparent_color);
+                surface->m_transparent_color);
         }
         else
         {


### PR DESCRIPTION
The previous code was using a potential wrong transparent color during rendering. This has been changed to use the one specified in the actual surface instance. The change affects both when the sprite is created and when it is rendered, ensuring consistent use of the specified transparent color.