### PR TITLE
Fix landscape buffer dimensions

### DIFF
--- a/lib/graphics/src/graphics.cpp
+++ b/lib/graphics/src/graphics.cpp
@@ -46,7 +46,7 @@ void graphics::init()
     // We need to create a "landscape buffer" used as a screen.
     // Because LovyanGFX as a weird color glitch when using "setRotation()".
     // But, by using a temporary buffer, the glitch doesn't appear.
-    landscapeBuffer = std::make_shared<Surface>(getScreenWidth(), getScreenHeight());
+    landscapeBuffer = std::make_shared<Surface>(getScreenHeight(), getScreenWidth());
 
 #endif
 


### PR DESCRIPTION
Corrected the order of width and height parameters when creating the landscape buffer.