### PR TITLE
Adjust window size to screen dimensions

### DIFF
--- a/lib/gui/src/elements/Window.cpp
+++ b/lib/gui/src/elements/Window.cpp
@@ -13,8 +13,8 @@ namespace gui::elements {
     {
         m_x = 0;
         m_y = 0;
-        m_width = 320;
-        m_height = 480;
+        m_width = graphics::getScreenWidth();
+        m_height = graphics::getScreenHeight();
         m_backgroundColor = COLOR_WHITE;
     }
 


### PR DESCRIPTION
The window's default width and height are now dynamically set to the screen's width and height using the graphics::getScreenWidth() and graphics::getScreenHeight() functions respectively, replacing the previous hardcoded values of 320x480.