### PR TITLE
Update platformio configs for Windows build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -48,7 +48,7 @@ build_unflags =
     -std=gnu++11
     -std=gnu++14
 
-; You need to have mingw32/mingw64 installed
+; You need to have mingw64 installed
 [env:windows]
 platform = native
 lib_deps =
@@ -57,12 +57,14 @@ test_framework = googletest
 test_testing_command =
     ${platformio.build_dir}/${this.__env__}/program
 build_flags =
-    -std=c++23
+    -std=c++17
     -lm
     -Iextern/SDL2-2.28.5/x86_64-w64-mingw32/include/SDL2
     -Lextern/SDL2-2.28.5/x86_64-w64-mingw32/lib
     -lSDL2main
     -lSDL2
+    -m64
+    -Wa,-mbig-obj
 extra_scripts =
     pre:scripts/platformio/windows/setup_workspace.py
     pre:scripts/platformio/windows/copy_dependencies.py


### PR DESCRIPTION
Changed C++ standard to C++17 and updated mingw requirement to mingw64 only. Added build flags '-m64' and '-Wa,-mbig-obj' to address compilation for 64-bit architecture.