### PR TITLE
Fixed GitHub actions workflow to only run on "main"

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -3,10 +3,10 @@ name: PlatformIO
 on:
   push:
     branches: 
-        - '**'
+        - main
   pull_request:
     branches:
-        - '**'
+        - main
 
 jobs:
     espBuild:


### PR DESCRIPTION
Fixed GitHub actions workflow to only run on "main" to save some task time.