### PR TITLE
[TO BE CLOSED] added sdl links to linux init

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -112,6 +112,8 @@ build_flags =
 	-lSDL2main
 	-lSDL2
 	-g
+	-I/usr/local/include/SDL2
+	-L/usr/local/lib
 
 [env:macos]
 platform = native


### PR DESCRIPTION
EDIT: Please discard this PR (I don't think I have enough permissions to close it). What really helped was installing the platformio extension on VS Code prior to this modification.

ORIGINAL COMMENT: The compilation was not working on linux. Adding the SDL links did the trick. Tested on Ubuntu 22.

