### PR TITLE
Add new compiler and linker flags to platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -72,7 +72,6 @@ build_flags =
     -lSDL2
     -m64
     -Wa,-mbig-obj
-	-flto
 	-Wl,-allow-multiple-definition,--stack,16777216
 extra_scripts =
     pre:scripts/platformio/windows/setup_workspace.py
@@ -96,7 +95,6 @@ build_flags =
     -lSDL2
     -m64
     -Wa,-mbig-obj
-	-flto
 	-Wl,-allow-multiple-definition,--stack,16777216
 extra_scripts =
     pre:scripts/platformio/windows/setup_workspace.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -72,6 +72,8 @@ build_flags =
     -lSDL2
     -m64
     -Wa,-mbig-obj
+	-flto
+	-Wl,-allow-multiple-definition,--stack,16777216
 extra_scripts =
     pre:scripts/platformio/windows/setup_workspace.py
     pre:scripts/platformio/windows/copy_dependencies.py
@@ -94,6 +96,8 @@ build_flags =
     -lSDL2
     -m64
     -Wa,-mbig-obj
+	-flto
+	-Wl,-allow-multiple-definition,--stack,16777216
 extra_scripts =
     pre:scripts/platformio/windows/setup_workspace.py
     pre:scripts/platformio/windows/copy_dependencies.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,6 +73,7 @@ build_flags =
     -m64
     -Wa,-mbig-obj
 	-Wl,-allow-multiple-definition,--stack,16777216
+	-Os
 extra_scripts =
     pre:scripts/platformio/windows/setup_workspace.py
     pre:scripts/platformio/windows/copy_dependencies.py
@@ -96,6 +97,7 @@ build_flags =
     -m64
     -Wa,-mbig-obj
 	-Wl,-allow-multiple-definition,--stack,16777216
+	-Os
 extra_scripts =
     pre:scripts/platformio/windows/setup_workspace.py
     pre:scripts/platformio/windows/copy_dependencies.py


### PR DESCRIPTION
The commit introduces two new flags - `-flto` and `-Wl,-allow-multiple-definition,--stack,16777216` for compilation and linking processes. This is aimed at optimizing the program efficiency and handling potential issues with stack size and multiple definitions.