### PR TITLE
Add display name support in app manifest

### DIFF
--- a/lib/applications/src/app.hpp
+++ b/lib/applications/src/app.hpp
@@ -17,6 +17,7 @@ namespace app
     struct App
     {
         std::string name;
+        std::string displayName;
         storage::Path path;
         storage::Path manifest;
         bool auth;

--- a/lib/applications/src/launcher.cpp
+++ b/lib/applications/src/launcher.cpp
@@ -67,7 +67,7 @@ int launcher()
         box->addChild(img);
 
         Label* text = new Label(0, 46, 80, 34);
-        text->setText(app::appList[i].name);
+        text->setText(app::appList[i].displayName);
         text->setVerticalAlignment(Label::Alignement::CENTER);
         text->setHorizontalAlignment(Label::Alignement::CENTER);
         text->setFontSize(16);


### PR DESCRIPTION
Updated the application initialization code to support custom display names for applications in the app manifest. This allows apps to specify a custom name that appears on the launcher. For apps without a custom name, the directory name will be used.