### PR TITLE
Bugfix - Replace incorrect method in Keyboard.cpp

### DIFF
--- a/lib/gui/src/elements/Keyboard.cpp
+++ b/lib/gui/src/elements/Keyboard.cpp
@@ -396,7 +396,7 @@ namespace gui::elements {
                     m_caps = CAPS_NONE;
 
                     drawKeys();
-                    updateLayoutIcon(); // Fix bug
+                    updateCapsIcon(); // Fix bug
 
                     return;
                 }


### PR DESCRIPTION
**Tested on :**
* Windows 11 x64