### PR TITLE
fix: fix macos compilation error

### DIFF
--- a/lib/lua/src/SOL2/sol.hpp
+++ b/lib/lua/src/SOL2/sol.hpp
@@ -6818,7 +6818,8 @@ namespace sol {
 			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
 
 			*this = nullopt;
-			this->construct(std::forward<Args>(args)...);
+			new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
+			return **this;
 		}
 
 		/// Swaps this optional with the other.


### PR DESCRIPTION
Fixes the issue `lib/lua/src/SOL2/sol.hpp:6821:10: error: no member named 'construct' in 'optional<type-parameter-0-0 &>'`  when compiling PaxOS on macOS, fix from [`d805d02`](https://github.com/ThePhD/sol2/commit/d805d027e0a0a7222e936926139f06e23828ce9f).