### PR TITLE
Use macOS to compile paxo-v5 for CI

### DIFF
--- a/.github/workflows/platformio-ci.yml
+++ b/.github/workflows/platformio-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     paxo_v5_build_test_upload:
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
 
         steps:
           - name: Checkout repository


### PR DESCRIPTION
Takes 2 minutes less