### PR TITLE
Add a battery check and minor refactoring of main.cpp.

### DIFF
--- a/lib/applications/src/launcher.cpp
+++ b/lib/applications/src/launcher.cpp
@@ -116,7 +116,11 @@ void applications::launcher::update() {
         static double lastBattery = Gsm::getBatteryLevel();
         if(lastBattery != Gsm::getBatteryLevel())
         {
-            batteryLabel->setText(std::to_string(static_cast<int>(Gsm::getBatteryLevel() * 100)) + "%");
+            if (Gsm::getBatteryLevel() < 0.0) {
+                batteryLabel->setText("X");
+            } else {
+                batteryLabel->setText(std::to_string(static_cast<int>(Gsm::getBatteryLevel() * 100)) + "%");
+            }
 
             lastBattery = Gsm::getBatteryLevel();
         }
@@ -253,7 +257,11 @@ void applications::launcher::draw() {
 
     // Battery label
     batteryLabel = new Label(255, 10, 40, 18);
-    batteryLabel->setText(std::to_string(static_cast<int>(Gsm::getBatteryLevel() * 100)) + "%");
+    if (Gsm::getBatteryLevel() < 0.0) {
+        batteryLabel->setText("X");
+    } else {
+        batteryLabel->setText(std::to_string(static_cast<int>(Gsm::getBatteryLevel() * 100)) + "%");
+    }
     batteryLabel->setVerticalAlignment(Label::Alignement::CENTER);
     batteryLabel->setHorizontalAlignment(Label::Alignement::RIGHT);
     batteryLabel->setFontSize(18);

--- a/lib/gsm/src/gsm2.cpp
+++ b/lib/gsm/src/gsm2.cpp
@@ -961,7 +961,7 @@ namespace Gsm
     double getBatteryLevel() {
 #ifdef ESP_PLATFORM
         if (currentVoltage_mV == -1) {
-            return 1;
+            return -1.0;
         }
         const double voltage_V = currentVoltage_mV / 1000.0;
         const double batteryLevel = 3.083368 * std::pow(voltage_V, 3) - 37.21203 * std::pow(voltage_V, 2) + 150.5735 * voltage_V - 203.3347;

--- a/lib/system/libsystem.cpp
+++ b/lib/system/libsystem.cpp
@@ -179,14 +179,29 @@ void libsystem::panic(const std::string &message, const bool restart)
 
 void libsystem::log(const std::string &message)
 {
-    std::cout << "[LOG] " << message << std::endl;
+    info(message);
+}
+
+void libsystem::info(const std::string &message)
+{
+    std::cout << "[INFO] " << message << std::endl;
+}
+
+void libsystem::warn(const std::string &message)
+{
+    std::cout << "[WARN] " << message << std::endl;
+}
+
+void libsystem::error(const std::string &message)
+{
+    std::cerr << "[ERROR] " << message << std::endl;
 }
 
 void libsystem::registerBootError(const std::string &message)
 {
     bootErrors.emplace_back(message);
 
-    log("[Boot Error] " + message);
+    error("Boot: " + message);
 }
 
 bool libsystem::hasBootErrors()
@@ -264,6 +279,7 @@ libsystem::DeviceMode libsystem::getDeviceMode()
 
 libsystem::FileConfig libsystem::getSystemConfig()
 {
+    // FIXME: Are we copying the shared pointer here?
     return *systemConfig;
 }
 

--- a/lib/system/libsystem.hpp
+++ b/lib/system/libsystem.hpp
@@ -5,7 +5,6 @@
 #ifndef LIBSYSTEM_HPP
 #define LIBSYSTEM_HPP
 
-#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <color.hpp>
@@ -55,7 +54,29 @@ namespace libsystem
      *
      * @todo Save logs.
      */
+    [[deprecated("Use libsystem::info(), libsystem::warn() and libsystem::error() instead.")]]
     void log(const std::string &message);
+
+    /**
+     * @brief Log an info message.
+     *
+     * @param message The log message.
+     */
+    void info(const std::string &message);
+
+    /**
+     * @brief Log a warning message.
+     *
+     * @param message The log message.
+     */
+    void warn(const std::string &message);
+
+    /**
+     * @brief Log an error message.
+     *
+     * @param message The log message.
+     */
+    void error(const std::string &message);
 
     /**
      * @defgroup boot_errors Error management at boot time.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,6 +194,20 @@ static bool initGraphics()
     return true;
 }
 
+static bool checkBattery() {
+    if (hardware::input::getButtonState(hardware::input::HOME) == hardware::input::PRESSED) {
+        libsystem::info("Battery check skipped by HOME button press.");
+        return true;
+    }
+    if (Gsm::getBatteryLevel() < 0.0) {
+        libsystem::registerBootError("Battery error.");
+        libsystem::registerBootError("Hold the HOME button when booting to skip this check.");
+        return false;
+    }
+    libsystem::info("Battery level: " + std::to_string(Gsm::getBatteryLevel()));
+    return true;
+}
+
 static bool initStorage()
 {
     if (!storage::init()) {
@@ -274,14 +288,11 @@ void init([[maybe_unused]] void *data)
         libsystem::restart(true, 10000);
         return;
     }
-
-    if (Gsm::getBatteryLevel() < 0.0) {
-        libsystem::registerBootError("Battery error.");
+    if (!checkBattery()) {
         libsystem::displayBootErrors();
         libsystem::restart(true, 10000);
         return;
     }
-
     if (!initStorage()) {
         libsystem::displayBootErrors();
         libsystem::restart(true, 10000);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,12 +256,12 @@ static bool registerEventHandlers() {
     return true;
 }
 
-void init(void* data)
+void init([[maybe_unused]] void *data)
 {
     ThreadManager::init();
 #ifdef ESP_PLATFORM
     ThreadManager::new_thread(CORE_BACK, &serialcom::SerialManager::serialLoop);
-    ThreadManager::new_thread(CORE_BACK, &hardware::vibrator::thread, 2*1024);
+    ThreadManager::new_thread(CORE_BACK, &hardware::vibrator::thread, 2 * 1024);
 #endif // ESP_PLATFORM
 
     hardware::init();


### PR DESCRIPTION
This pull request refactors the initialization process, improves logging capabilities, and enhances battery management logic. Key changes include splitting the `init` function into modular components, introducing new logging methods, and refining battery level handling.

### Refactoring Initialization Process:
* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L180-L192): Split the `init` function into modular components (`initGraphics`, `checkBattery`, `initStorage`, `initLibSystem`, and `registerEventHandlers`) for better readability and maintainability. Added conditional checks to handle initialization errors gracefully. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L180-L192) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R190-R338)

### Logging Enhancements:
* [`lib/system/libsystem.cpp`](diffhunk://#diff-14332c1aaccfd04891e958433a652056913c11023e625fda0d51f0d9443220f0L182-R204): Introduced new logging methods (`info`, `warn`, `error`) to replace the generic `log` function. Updated existing calls to use these methods for better log categorization.
* [`lib/system/libsystem.hpp`](diffhunk://#diff-db0804c2027f0cf079e7f5a004b06842611d48eb5cf400fd0e470b039a361da4R57-R80): Deprecated the `log` function and added documentation for the new logging methods.

### Battery Management Improvements:
* [`lib/applications/src/launcher.cpp`](diffhunk://#diff-41cfffd7a16f4cc5a6426fc122787decc9e50c83d4e4615e1628eed77b8e0e1eR119-R123): Enhanced battery label logic to display "X" when the battery level is invalid (negative). [[1]](diffhunk://#diff-41cfffd7a16f4cc5a6426fc122787decc9e50c83d4e4615e1628eed77b8e0e1eR119-R123) [[2]](diffhunk://#diff-41cfffd7a16f4cc5a6426fc122787decc9e50c83d4e4615e1628eed77b8e0e1eR260-R264)
* [`lib/gsm/src/gsm2.cpp`](diffhunk://#diff-b74b6550ea0e8cfc2c3b59321af6bf383b41851e5f4981dc2441b91f07a887b1L964-R964): Updated the `getBatteryLevel` function to return `-1.0` when the battery voltage is invalid, signaling an error state.

### Minor Fixes and Code Cleanup:
* [`lib/system/libsystem.cpp`](diffhunk://#diff-14332c1aaccfd04891e958433a652056913c11023e625fda0d51f0d9443220f0R282): Added a `FIXME` comment in `getSystemConfig` regarding potential shared pointer copying.
* [`lib/system/libsystem.hpp`](diffhunk://#diff-db0804c2027f0cf079e7f5a004b06842611d48eb5cf400fd0e470b039a361da4L8): Removed an unused `#include <cstdint>` directive.