### PR TITLE
Change platformio.ini to use a better structure, upgrade C/C++ versions, update libraries versions and fix windows compilation issue.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ lib_deps =
 	bitbank2/FT6236G@^1.0.0
 	bitbank2/PNGdec@^1.1.3
 build_flags =
-	-std=gnu++20
+	-std=gnu++2a
 	-std=gnu17
 	-lm
 	-Iinclude


### PR DESCRIPTION
This pull request refactors the `platformio.ini` configuration file, introducing shared environment variables and dependencies to reduce duplication and improve maintainability. Key changes include consolidating build flags and library dependencies into a common environment (`env:native`) and extending it for other environments. Additionally, outdated library versions and redundant flags are removed.

### Consolidation of Shared Settings:
* Introduced a new `env:native` environment to centralize common build flags and dependencies shared across multiple environments. This includes libraries (`LovyanGFX`, `FT6236G`, `PNGdec`) and flags (`-std=gnu++2a`, `-lm`, `-Iinclude`).

### Removal of Redundancy:
* Replaced individual environment-specific build flags and dependencies with references to `env:native` settings, reducing duplication across `windows`, `linux`, `macos`, and `test` environments. [[1]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L83-L99) [[2]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L109-L165)

### Updates to Library Versions:
* Updated library dependencies to newer versions (`LovyanGFX@^1.2.7`, `PNGdec@^1.1.3`) for improved functionality and compatibility. [[1]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R16-R37) [[2]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L25-L35)

### Cleanup of Build Flags:
* Removed outdated or redundant build flags (`-std=gnu++11`, `-std=gnu++14`, `-std=c++17`) and replaced them with modern standards (`-std=gnu++2a`, `-std=gnu17`). [[1]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R16-R37) [[2]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L47-L72)

### Environment-Specific Adjustments:
* Ensured platform-specific settings (e.g., SDL2 includes and libraries for `windows`, `linux`, and `macos`) are preserved while extending the shared `env:native` configuration. [[1]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L83-L99) [[2]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L109-L165)